### PR TITLE
Require julia-0.7 or higher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 deps/installed_vers
 deps/libemd.dylib
 deps/libemd.so
+deps/*.log

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5
-DocOpt.jl
+julia 0.7

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,4 @@
-using BinDeps
-using Compat
+using Libdl
 
 vers = "2.0" # Use version number in setup.py file of pyEMD: https://raw.githubusercontent.com/garydoranjr/pyemd/master/setup.py
 

--- a/deps/translate_c.jl
+++ b/deps/translate_c.jl
@@ -13,7 +13,7 @@
 
 function translate_c_file(srcfile, destfile)
     str = open(srcfile, "r") do fh
-        readstring(fh)
+        read(fh, String)
     end
     str = replace(str, "#include <emd.h>",                   "#include <emd_translated.h>")
 
@@ -31,7 +31,7 @@ function translate_c_file(srcfile, destfile)
         print(fh, str)
     end
 
-    print_with_color(:green, "Translated double matrix references in file $(srcfile) and saved in $(destfile)\n")
+    printstyled("Translated double matrix references in file $(srcfile) and saved in $(destfile)\n", color=:green)
 end
 
 translate_c_file(ARGS[1], ARGS[2])

--- a/make.jl
+++ b/make.jl
@@ -31,7 +31,7 @@ function update_emd()
         run(`wget https://raw.githubusercontent.com/garydoranjr/pyemd/master/c_emd/emd.c`)
         run(`wget https://raw.githubusercontent.com/garydoranjr/pyemd/master/c_emd/emd.h`)
     end
-    print_with_color(:green, "Downloaded latest emd c source files from pyEMD project on github.\n")
+    printstyled("Downloaded latest emd c source files from pyEMD project on github.\n", color=:green)
 end
 
 if arguments["update"] && arguments["emd"]
@@ -81,10 +81,10 @@ end
 
 if arguments["test"]
     if arguments["latest"]
-        print_with_color(:green, "Running latest changed test file.\n")
+        printstyled("Running latest changed test file.\n", color=:green)
         run(`julia --color=yes -L src/$(PackageName).jl $(latest_changed_testfile())`)
     else
-        print_with_color(:green, "Running all tests.\n")
+        printstyled("Running all tests.\n", color=:green)
         run(`julia --color=yes -L src/$(PackageName).jl test/runtests.jl`)
     end
 end

--- a/src/EarthMoversDistance.jl
+++ b/src/EarthMoversDistance.jl
@@ -1,16 +1,11 @@
-__precompile__()
-
 module EarthMoversDistance
 
 export emd
 
-using Compat
-import Compat.String
-
 const libemd = joinpath(dirname(@__FILE__), "..", "deps", "libemd")
 
 function __init__()
-    # If any init or destroy functions need to be called for the lib. 
+    # If any init or destroy functions need to be called for the lib.
     # In this case not, since emd is a "pure" function (no side effects).
     #ccall((:emd_init,libemd), Void, ())
     #atexit() do
@@ -28,8 +23,8 @@ libemd_emd(n_x, weight_x, n_y, weight_y, cost, flows) =
           n_x, weight_x, n_y, weight_y, cost, flows)
 
 # API
-function emd!(Xweight::Vector{Float64}, Yweight::Vector{Float64}, cost::Matrix{Float64}, 
-    flows::Union{Void, Matrix{Float64}} = nothing)
+function emd!(Xweight::Vector{Float64}, Yweight::Vector{Float64}, cost::Matrix{Float64},
+    flows::Union{Nothing, Matrix{Float64}} = nothing)
 
     n_x = length(Xweight)
     n_y = length(Yweight)
@@ -49,18 +44,18 @@ function emd!(Xweight::Vector{Float64}, Yweight::Vector{Float64}, cost::Matrix{F
     end
 end
 
-function emd(Xweight::Vector{Float64}, Yweight::Vector{Float64}, cost::Union{Void, Matrix{Float64}} = nothing)
+function emd(Xweight::Vector{Float64}, Yweight::Vector{Float64}, cost::Union{Nothing, Matrix{Float64}} = nothing)
     if cost == nothing
         cost = ones(Float64, length(Xweight), length(Yweight))
     end
     emd!(Xweight, Yweight, cost)
 end
 
-function emd_flows(Xweight::Vector{Float64}, Yweight::Vector{Float64}, cost::Union{Void, Matrix{Float64}} = nothing)
+function emd_flows(Xweight::Vector{Float64}, Yweight::Vector{Float64}, cost::Union{Nothing, Matrix{Float64}} = nothing)
     if cost == nothing
         cost = ones(Float64, length(Xweight), length(Yweight))
     end
-    flows = zeros(cost)
+    flows = zeros(eltype(cost), axes(cost))
     distance = emd!(Xweight, Yweight, cost, flows)
     return distance, flows
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Test
 
 @testset "EarthMoversDistance test suite" begin
     include("test_emd.jl")


### PR DESCRIPTION
This updates the package to julia 0.7 and julia 1.0. Tests pass locally for me.

Note also https://github.com/mirkobunse/EarthMoversDistance.jl. I initially used that in https://github.com/JuliaImages/ImageDistances.jl/pull/4, but I have been finding that I occasionally get really bizarre (aka, completely wrong) results. Note it uses a different (and older) C library than this package. So far, the C library used here seems to give reliable results. CC @mirkobunse.
